### PR TITLE
Implement dl.JSONObject structure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/go-playground/validator/v10 v10.9.0
+	github.com/google/uuid v1.3.0
 	github.com/spf13/viper v1.9.0
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/json_object.go
+++ b/json_object.go
@@ -28,10 +28,7 @@ func (j JSONObject) String() (s string) {
 
 // FromJSON creates JSONObject from JSON.
 func FromJSON(s string) (o JSONObject, err error) {
-	if err = json.Unmarshal([]byte(s), &o); err != nil {
-		o = JSONObject{}
-	}
-
+	err = json.Unmarshal([]byte(s), &o)
 	return
 }
 

--- a/json_object.go
+++ b/json_object.go
@@ -1,0 +1,45 @@
+package dl
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/google/uuid"
+)
+
+// JSONObject is a general structure to represent JavaScript objects.
+type JSONObject map[string]interface{}
+
+// Equal checks if the JSONObject has the same values with another one.
+func (j JSONObject) Equal(another JSONObject) bool {
+	return reflect.DeepEqual(j, another)
+}
+
+// String returns JSON text.
+func (j JSONObject) String() (s string) {
+	s = "{}"
+
+	if marshaled, err := json.Marshal(j); err == nil {
+		s = (string)(marshaled)
+	}
+
+	return
+}
+
+// FromJSON creates JSONObject from JSON.
+func FromJSON(s string) (o JSONObject, err error) {
+	err = json.Unmarshal([]byte(s), &o)
+	return
+}
+
+// WithNonce checks if the object contains `nonce` properties.
+// If not, then add one.
+func (j *JSONObject) WithNonce() {
+	if _, ok := (*j)["nonce"]; !ok {
+		(*j)["nonce"] = uuid.NewString()
+	}
+
+	if (*j)["nonce"] == "" {
+		(*j)["nonce"] = uuid.NewString()
+	}
+}

--- a/json_object.go
+++ b/json_object.go
@@ -28,7 +28,10 @@ func (j JSONObject) String() (s string) {
 
 // FromJSON creates JSONObject from JSON.
 func FromJSON(s string) (o JSONObject, err error) {
-	err = json.Unmarshal([]byte(s), &o)
+	if err = json.Unmarshal([]byte(s), &o); err != nil {
+		o = JSONObject{}
+	}
+
 	return
 }
 

--- a/json_object_test.go
+++ b/json_object_test.go
@@ -88,8 +88,8 @@ func Test_FromJSON_WithIncorrectJSON_ShouldNotReturnCorrectJSONObject(t *testing
 		t.Errorf("should NOT be able to parse JSON")
 	}
 
-	if object != nil {
-		t.Errorf("should be a nil JSONObject")
+	if !object.Equal(JSONObject{}) {
+		t.Errorf("should be an empty JSONObject")
 	}
 }
 

--- a/json_object_test.go
+++ b/json_object_test.go
@@ -1,0 +1,115 @@
+package dl
+
+import (
+	"testing"
+)
+
+func Test_EqualWithSameJsonObject_ShouldBeTrue(t *testing.T) {
+	var shouldBeEquivalent bool = JSONObject{
+		"object": JSONObject{
+			"number": 1.23,
+			"string": "string",
+		},
+	}.Equal(JSONObject{
+		"object": JSONObject{
+			"number": 1.23,
+			"string": "string",
+		},
+	})
+
+	if !shouldBeEquivalent {
+		t.Errorf("JSONObject.Equal should be able distinguish two JSONObject variables that have same values")
+	}
+
+}
+
+func Test_EqualWithDifferentJsonObject_ShouldBeFalse(t *testing.T) {
+	var shouldNotBeEquivalent bool = JSONObject{
+		"object": JSONObject{
+			"number": 0,
+			"string": "hello world",
+		},
+	}.Equal(JSONObject{
+		"object": JSONObject{
+			"number": 1.23,
+			"string": "string",
+		},
+	})
+
+	if shouldNotBeEquivalent {
+		t.Errorf("JSONObject.Equal should be able distinguish two JSONObject variables that have different values")
+	}
+}
+
+func Test_String_ShouldReturnCorrectJSON(t *testing.T) {
+	var (
+		object = JSONObject{
+			"string": "i-am-string",
+			"number": 0,
+			"array": []JSONObject{
+				{"in-array1": "array1"},
+				{"in-array2": "array2"},
+			},
+			"object": JSONObject{
+				"in-object": "object",
+			},
+		}
+
+		json = object.String()
+	)
+
+	if json != `{"array":[{"in-array1":"array1"},{"in-array2":"array2"}],"number":0,"object":{"in-object":"object"},"string":"i-am-string"}` {
+		t.Errorf("should return correct JSON")
+	}
+}
+
+func Test_FromJSON_WithCorrectJSON_ShouldReturnCorrectJSONObject(t *testing.T) {
+	var (
+		object JSONObject
+		err    error
+	)
+
+	if object, err = FromJSON(`{"foo":"bar"}`); err != nil {
+		t.Errorf("should be able to parse JSON")
+	}
+
+	if object["foo"] != "bar" {
+		t.Errorf("should return corect JSONObject")
+	}
+}
+
+func Test_FromJSON_WithIncorrectJSON_ShouldNotReturnCorrectJSONObject(t *testing.T) {
+	var (
+		object JSONObject
+		err    error
+	)
+
+	if object, err = FromJSON(``); err == nil {
+		t.Errorf("should NOT be able to parse JSON")
+	}
+
+	if object != nil {
+		t.Errorf("should be a nil JSONObject")
+	}
+}
+
+func Test_WithNonce_ShouldAddNonce(t *testing.T) {
+	var (
+		object JSONObject = JSONObject{}
+	)
+
+	object.WithNonce()
+
+	var (
+		nonce string
+		ok    bool
+	)
+
+	if nonce, ok = object["nonce"].(string); !ok {
+		t.Errorf("should add nonce")
+	}
+
+	if nonce == "" {
+		t.Errorf("should be uuid")
+	}
+}

--- a/json_object_test.go
+++ b/json_object_test.go
@@ -88,8 +88,8 @@ func Test_FromJSON_WithIncorrectJSON_ShouldNotReturnCorrectJSONObject(t *testing
 		t.Errorf("should NOT be able to parse JSON")
 	}
 
-	if !object.Equal(JSONObject{}) {
-		t.Errorf("should be an empty JSONObject")
+	if object != nil {
+		t.Errorf("should be a nil JSONObject")
 	}
 }
 


### PR DESCRIPTION
This PR implements dl.JSONObject structure to represent JavaScript object (generally, map[string]interface{} in Go)