### PR TITLE
Revise unit-test names

### DIFF
--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -1,12 +1,12 @@
 package config
 
-import (
-	"testing"
-)
+import "testing"
 
-func Test_NewClientConfigFromJson_WithEmptyObject_ShouldGetDefaultClientConfig(t *testing.T) {
-	var c ClientConfig
-	var err error
+func TestNewClientConfigFromJSON(t *testing.T) {
+	var (
+		c   ClientConfig
+		err error
+	)
 
 	if c, err = NewClientConfigFromJSON("{}"); err != nil {
 		t.Errorf("should be able to create default ClientConfig")
@@ -15,9 +15,204 @@ func Test_NewClientConfigFromJson_WithEmptyObject_ShouldGetDefaultClientConfig(t
 	if c != NewClientConfigWithDefaultValues() {
 		t.Errorf("ClientConfig should have default values")
 	}
+
+	var json = `
+{
+	"scalar.dl.client.server.host": "localhost",
+	"scalar.dl.client.server.port": 80,
+	"scalar.dl.client.server.privileged_port": 8080,
+	"scalar.dl.client.cert_holder_id": "foo",
+	"scalar.dl.client.cert_version": 100,
+	"scalar.dl.client.cert_pem": "cert_pem",
+	"scalar.dl.client.private_key_pem": "private_key_pem",
+	"scalar.dl.client.tls.enabled": true,
+	"scalar.dl.client.tls.ca_root_cert_pem": "ca_root_cert_pem",
+	"scalar.dl.client.authorization.credential": "credential",
+	"scalar.dl.client.mode": "INTERMEDIARY",
+	"scalar.dl.client.proxy.server": "127.0.0.1",
+	"scalar.dl.client.auditor.enabled": true,
+	"scalar.dl.client.auditor.host": "localhost",
+	"scalar.dl.client.auditor.port": 4040,
+	"scalar.dl.client.auditor.privileged_port": 40400,
+	"scalar.dl.client.auditor.linearizable_validation.enabled": true,
+	"scalar.dl.client.auditor.linearizable_validation.contract_id": "linearizable"
+}
+`
+
+	if c, err = NewClientConfigFromJSON(json); err != nil {
+		t.Errorf("can't load JSON %s", json)
+	}
+
+	if c.LedgerHost != "localhost" {
+		t.Errorf("LedgerHost is not match")
+	}
+
+	if c.LedgerPort != 80 {
+		t.Errorf("LedgerPort is not match")
+	}
+
+	if c.LedgerPrivilegedPort != 8080 {
+		t.Errorf("LedgerPrivilegedPort is not match")
+	}
+
+	if c.CertHolderID != "foo" {
+		t.Errorf("CertHolderID is not match")
+	}
+
+	if c.CertVersion != 100 {
+		t.Errorf("CertVersion is not match")
+	}
+
+	if c.Cert != "cert_pem" {
+		t.Errorf("Cert is not match")
+	}
+
+	if c.PrivateKey != "private_key_pem" {
+		t.Errorf("PrivateKey is not match")
+	}
+
+	if !c.IsTLSEnabled {
+		t.Errorf("IsTLSEnabled is not match")
+	}
+
+	if c.TLSCaRootCert != "ca_root_cert_pem" {
+		t.Errorf("TLSCaRootCert is not match")
+	}
+
+	if c.AuthorizationCredential != "credential" {
+		t.Errorf("AuthorizationCredential is not match")
+	}
+
+	if c.ClientMode != "INTERMEDIARY" {
+		t.Errorf("ClientMode is not match")
+	}
+
+	if c.ProxyServer != "127.0.0.1" {
+		t.Errorf("ProxyServer is not match")
+	}
+
+	if !c.IsAuditorEnabled {
+		t.Errorf("IsAuditorEnabled is not match")
+	}
+
+	if c.AuditorHost != "localhost" {
+		t.Errorf("AuditorHost is not match")
+	}
+
+	if c.AuditorPort != 4040 {
+		t.Errorf("AuditorPort is not match")
+	}
+
+	if c.AuditorPrivilegedPort != 40400 {
+		t.Errorf("AuditorPrivilegedPort is not match")
+	}
+
+	if !c.IsAuditorLinearizableValidationEnabled {
+		t.Errorf("IsAuditorLinearizableValidationEnabled is not match")
+	}
+
+	if c.AuditorLinearizableValidationContractID != "linearizable" {
+		t.Errorf("AuditorLinearizableValidationContractID is not match")
+	}
+
+	var withoutCertHolderID = `
+{
+	"scalar.dl.client.cert_pem": "cert_pem",
+	"scalar.dl.client.private_key_pem": "private_key_pem"
+}
+`
+
+	if c, err = NewClientConfigFromJSON(withoutCertHolderID); err != nil {
+		t.Errorf("can't load JSON %s", withoutCertHolderID)
+	}
+
+	if err = c.Validate(); err == nil {
+		t.Errorf("should not be validated without CertHolderId")
+	}
+
+	var withoutCertPem = `
+{
+	"scalar.dl.client.cert_holder_id": "foo",
+	"scalar.dl.client.private_key_pem": "private_key_pem"
+}
+`
+
+	if c, err = NewClientConfigFromJSON(withoutCertPem); err != nil {
+		t.Errorf("can't load JSON %s", withoutCertPem)
+	}
+
+	if err = c.Validate(); err == nil {
+		t.Errorf("should not be validated without Cert")
+	}
+
+	var withoutPrivateKeyPem = `
+{
+	"scalar.dl.client.cert_holder_id": "foo",
+	"scalar.dl.client.cert_pem": "cert_pem"
+}
+`
+
+	if c, err = NewClientConfigFromJSON(withoutPrivateKeyPem); err != nil {
+		t.Errorf("can't load JSON %s", withoutPrivateKeyPem)
+	}
+
+	if err = c.Validate(); err == nil {
+		t.Errorf("should not be validated without PrivateKey")
+	}
+
+	var withoutTLSCaRootCert = `
+{
+	"scalar.dl.client.cert_holder_id": "foo",
+	"scalar.dl.client.cert_pem": "cert_pem",
+	"scalar.dl.client.private_key_pem": "private_key_pem",
+	"scalar.dl.client.tls.enabled": true
+}
+`
+
+	if c, err = NewClientConfigFromJSON(withoutTLSCaRootCert); err != nil {
+		t.Errorf("can't load JSON %s", withoutTLSCaRootCert)
+	}
+
+	if err = c.Validate(); err == nil {
+		t.Errorf("should not be validated without TLSCaRootCert")
+	}
+
+	var withInvalidClientMode = `
+{
+	"scalar.dl.client.cert_holder_id": "foo",
+	"scalar.dl.client.cert_pem": "cert_pem",
+	"scalar.dl.client.private_key_pem": "private_key_pem",
+	"scalar.dl.client.mode": "invalidmode"
+}
+`
+
+	if c, err = NewClientConfigFromJSON(withInvalidClientMode); err != nil {
+		t.Errorf("can't load JSON %s", withInvalidClientMode)
+	}
+
+	if err = c.Validate(); err == nil {
+		t.Errorf("should not be validated with invalid ClientMode")
+	}
+
+	var withoutAuditorTLSCaRootCert = `
+{
+	"scalar.dl.client.cert_holder_id": "foo",
+	"scalar.dl.client.cert_pem": "cert_pem",
+	"scalar.dl.client.private_key_pem": "private_key_pem",
+	"scalar.dl.client.auditor.tls.enabled": true
+}
+`
+
+	if c, err = NewClientConfigFromJSON(withoutAuditorTLSCaRootCert); err != nil {
+		t.Errorf("can't load JSON %s", withoutAuditorTLSCaRootCert)
+	}
+
+	if err = c.Validate(); err == nil {
+		t.Errorf("should not be validated without AuditorTLSCaRootCert")
+	}
 }
 
-func Test_NewClientConfigFromJavaProperties_WithCorrectObject_ShouldGetCorrectClientConfig(t *testing.T) {
+func TestNewClientConfigFromJavaProperties(t *testing.T) {
 	var javaProperties = `
 scalar.dl.client.server.host=localhost
 scalar.dl.client.server.port=80
@@ -116,209 +311,5 @@ scalar.dl.client.auditor.linearizable_validation.contract_id=linearizable
 
 	if c.AuditorLinearizableValidationContractID != "linearizable" {
 		t.Errorf("AuditorLinearizableValidationContractID is not match")
-	}
-}
-
-func Test_NewClientConfigFromJson_WithCorrectObject_ShouldGetCorrectClientConfig(t *testing.T) {
-	var json = `
-{
-	"scalar.dl.client.server.host": "localhost",
-	"scalar.dl.client.server.port": 80,
-	"scalar.dl.client.server.privileged_port": 8080,
-	"scalar.dl.client.cert_holder_id": "foo",
-	"scalar.dl.client.cert_version": 100,
-	"scalar.dl.client.cert_pem": "cert_pem",
-	"scalar.dl.client.private_key_pem": "private_key_pem",
-	"scalar.dl.client.tls.enabled": true,
-	"scalar.dl.client.tls.ca_root_cert_pem": "ca_root_cert_pem",
-	"scalar.dl.client.authorization.credential": "credential",
-	"scalar.dl.client.mode": "INTERMEDIARY",
-	"scalar.dl.client.proxy.server": "127.0.0.1",
-	"scalar.dl.client.auditor.enabled": true,
-	"scalar.dl.client.auditor.host": "localhost",
-	"scalar.dl.client.auditor.port": 4040,
-	"scalar.dl.client.auditor.privileged_port": 40400,
-	"scalar.dl.client.auditor.linearizable_validation.enabled": true,
-	"scalar.dl.client.auditor.linearizable_validation.contract_id": "linearizable"
-}
-`
-	var c ClientConfig
-	var err error
-
-	if c, err = NewClientConfigFromJSON(json); err != nil {
-		t.Errorf("can't load JSON %s", json)
-	}
-
-	if c.LedgerHost != "localhost" {
-		t.Errorf("LedgerHost is not match")
-	}
-
-	if c.LedgerPort != 80 {
-		t.Errorf("LedgerPort is not match")
-	}
-
-	if c.LedgerPrivilegedPort != 8080 {
-		t.Errorf("LedgerPrivilegedPort is not match")
-	}
-
-	if c.CertHolderID != "foo" {
-		t.Errorf("CertHolderId is not match")
-	}
-
-	if c.CertVersion != 100 {
-		t.Errorf("CertVersion is not match")
-	}
-
-	if c.Cert != "cert_pem" {
-		t.Errorf("Cert is not match")
-	}
-
-	if c.PrivateKey != "private_key_pem" {
-		t.Errorf("PrivateKey is not match")
-	}
-
-	if !c.IsTLSEnabled {
-		t.Errorf("IsTLSEnabled is not match")
-	}
-
-	if c.TLSCaRootCert != "ca_root_cert_pem" {
-		t.Errorf("TLSCaRootCert is not match")
-	}
-
-	if c.AuthorizationCredential != "credential" {
-		t.Errorf("AuthorizationCredential is not match")
-	}
-
-	if c.ClientMode != "INTERMEDIARY" {
-		t.Errorf("ClientMode is not match")
-	}
-
-	if c.ProxyServer != "127.0.0.1" {
-		t.Errorf("ProxyServer is not match")
-	}
-
-	if !c.IsAuditorEnabled {
-		t.Errorf("IsAuditorEnabled is not match")
-	}
-
-	if c.AuditorHost != "localhost" {
-		t.Errorf("AuditorHost is not match")
-	}
-
-	if c.AuditorPort != 4040 {
-		t.Errorf("AuditorPort is not match")
-	}
-
-	if c.AuditorPrivilegedPort != 40400 {
-		t.Errorf("AuditorPrivilegedPort is not match")
-	}
-
-	if !c.IsAuditorLinearizableValidationEnabled {
-		t.Errorf("IsAuditorLinearizableValidationEnabled is not match")
-	}
-
-	if c.AuditorLinearizableValidationContractID != "linearizable" {
-		t.Errorf("AuditorLinearizableValidationContractID is not match")
-	}
-}
-
-func Test_NewClientConfigFromJson_WithInvalidJson_ShouldNotBeValidated(t *testing.T) {
-	var c ClientConfig
-	var err error
-
-	var withoutCertHolderID = `
-{
-	"scalar.dl.client.cert_pem": "cert_pem",
-	"scalar.dl.client.private_key_pem": "private_key_pem"
-}
-`
-
-	if c, err = NewClientConfigFromJSON(withoutCertHolderID); err != nil {
-		t.Errorf("can't load JSON %s", withoutCertHolderID)
-	}
-
-	if err = c.Validate(); err == nil {
-		t.Errorf("should not be validated without CertHolderId")
-	}
-
-	var withoutCertPem = `
-{
-	"scalar.dl.client.cert_holder_id": "foo",
-	"scalar.dl.client.private_key_pem": "private_key_pem"
-}
-`
-
-	if c, err = NewClientConfigFromJSON(withoutCertPem); err != nil {
-		t.Errorf("can't load JSON %s", withoutCertPem)
-	}
-
-	if err = c.Validate(); err == nil {
-		t.Errorf("should not be validated without Cert")
-	}
-
-	var withoutPrivateKeyPem = `
-{
-	"scalar.dl.client.cert_holder_id": "foo",
-	"scalar.dl.client.cert_pem": "cert_pem"
-}
-`
-
-	if c, err = NewClientConfigFromJSON(withoutPrivateKeyPem); err != nil {
-		t.Errorf("can't load JSON %s", withoutPrivateKeyPem)
-	}
-
-	if err = c.Validate(); err == nil {
-		t.Errorf("should not be validated without PrivateKey")
-	}
-
-	var withoutTLSCaRootCert = `
-{
-	"scalar.dl.client.cert_holder_id": "foo",
-	"scalar.dl.client.cert_pem": "cert_pem",
-	"scalar.dl.client.private_key_pem": "private_key_pem",
-	"scalar.dl.client.tls.enabled": true
-}
-`
-
-	if c, err = NewClientConfigFromJSON(withoutTLSCaRootCert); err != nil {
-		t.Errorf("can't load JSON %s", withoutTLSCaRootCert)
-	}
-
-	if err = c.Validate(); err == nil {
-		t.Errorf("should not be validated without TLSCaRootCert")
-	}
-
-	var withInvalidClientMode = `
-{
-	"scalar.dl.client.cert_holder_id": "foo",
-	"scalar.dl.client.cert_pem": "cert_pem",
-	"scalar.dl.client.private_key_pem": "private_key_pem",
-	"scalar.dl.client.mode": "invalidmode"
-}
-`
-
-	if c, err = NewClientConfigFromJSON(withInvalidClientMode); err != nil {
-		t.Errorf("can't load JSON %s", withInvalidClientMode)
-	}
-
-	if err = c.Validate(); err == nil {
-		t.Errorf("should not be validated with invalid ClientMode")
-	}
-
-	var withoutAuditorTLSCaRootCert = `
-{
-	"scalar.dl.client.cert_holder_id": "foo",
-	"scalar.dl.client.cert_pem": "cert_pem",
-	"scalar.dl.client.private_key_pem": "private_key_pem",
-	"scalar.dl.client.auditor.tls.enabled": true
-}
-`
-
-	if c, err = NewClientConfigFromJSON(withoutAuditorTLSCaRootCert); err != nil {
-		t.Errorf("can't load JSON %s", withoutAuditorTLSCaRootCert)
-	}
-
-	if err = c.Validate(); err == nil {
-		t.Errorf("should not be validated without AuditorTLSCaRootCert")
 	}
 }

--- a/client/error/error_test.go
+++ b/client/error/error_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/scalar-labs/dl/ledger/statuscode"
 )
 
-func Test_NewClientError_StatusCodeAndMessage_ShouldBeSuccessful(t *testing.T) {
+func TestNewClientError(t *testing.T) {
 	var err ClientError = ClientError{
 		statusCode: 401,
 		message:    "error message",

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -2,13 +2,11 @@ package crypto
 
 import "testing"
 
-func Test_NewEcSha256Signer_WithIncorrectKey_ShouldGetError(t *testing.T) {
+func Test_NewEcdsaSha256Signer(t *testing.T) {
 	if _, err := NewEcdsaSha256Signer([]byte("not a key")); err == nil {
 		t.Errorf("should get an error")
 	}
-}
 
-func Test_NewEcSha256Signer_WithCorrectKey_ShouldGetInstance(t *testing.T) {
 	var key string = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49
 AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20
@@ -21,7 +19,37 @@ XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==
 	}
 }
 
-func Test_EcSha256Signer_WithCorrectKey_ShouldSignCorrectly(t *testing.T) {
+func Test_EcdsaSha256Signer_Sign(t *testing.T) {
+	var (
+		privateKey string = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49
+AwEHoUQDQgAEBGuhqumyh7BVNqcNKAQQipDGooUpURve2dO66pQCgjtSfu7lJV20
+XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==
+-----END EC PRIVATE KEY-----
+`
+		s         Signer
+		err       error
+		signature []byte
+	)
+
+	if s, err = NewEcdsaSha256Signer([]byte(privateKey)); err != nil {
+		t.Errorf("should get an correct signer instance")
+	}
+
+	if signature, err = s.Sign([]byte("hello world!")); err != nil {
+		t.Errorf("should be able to sign")
+	}
+
+	if len(signature) < 2 || len(signature) < (int(signature[1])-2) {
+		t.Errorf("signature is in an incorrect length")
+	}
+
+	if int(signature[0]) != 48 {
+		t.Errorf("signature has an incorrect first-byte")
+	}
+}
+
+func Test_EcdsaSha256Signer_Verify(t *testing.T) {
 	var (
 		privateKey string = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -2,7 +2,7 @@ package crypto
 
 import "testing"
 
-func Test_NewEcdsaSha256Signer(t *testing.T) {
+func TestNewEcdsaSha256Signer(t *testing.T) {
 	if _, err := NewEcdsaSha256Signer([]byte("not a key")); err == nil {
 		t.Errorf("should get an error")
 	}
@@ -19,7 +19,7 @@ XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==
 	}
 }
 
-func Test_EcdsaSha256Signer_Sign(t *testing.T) {
+func TestEcdsaSha256Signer_Sign(t *testing.T) {
 	var (
 		privateKey string = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49
@@ -49,7 +49,7 @@ XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==
 	}
 }
 
-func Test_EcdsaSha256Signer_Verify(t *testing.T) {
+func TestEcdsaSha256Signer_Verify(t *testing.T) {
 	var (
 		privateKey string = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICcJGMEw3dyXUGFu/5a36HqY0ynZi9gLUfKgYWMYgr/IoAoGCCqGSM49

--- a/json_object_test.go
+++ b/json_object_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_EqualWithSameJsonObject_ShouldBeTrue(t *testing.T) {
+func Test_JSONObject_Equal(t *testing.T) {
 	var shouldBeEquivalent bool = JSONObject{
 		"object": JSONObject{
 			"number": 1.23,
@@ -21,9 +21,6 @@ func Test_EqualWithSameJsonObject_ShouldBeTrue(t *testing.T) {
 		t.Errorf("JSONObject.Equal should be able distinguish two JSONObject variables that have same values")
 	}
 
-}
-
-func Test_EqualWithDifferentJsonObject_ShouldBeFalse(t *testing.T) {
 	var shouldNotBeEquivalent bool = JSONObject{
 		"object": JSONObject{
 			"number": 0,
@@ -41,7 +38,7 @@ func Test_EqualWithDifferentJsonObject_ShouldBeFalse(t *testing.T) {
 	}
 }
 
-func Test_String_ShouldReturnCorrectJSON(t *testing.T) {
+func Test_JSONObject_String(t *testing.T) {
 	var (
 		object = JSONObject{
 			"string": "i-am-string",
@@ -63,7 +60,7 @@ func Test_String_ShouldReturnCorrectJSON(t *testing.T) {
 	}
 }
 
-func Test_FromJSON_WithCorrectJSON_ShouldReturnCorrectJSONObject(t *testing.T) {
+func Test_FromJSON(t *testing.T) {
 	var (
 		object JSONObject
 		err    error
@@ -76,13 +73,6 @@ func Test_FromJSON_WithCorrectJSON_ShouldReturnCorrectJSONObject(t *testing.T) {
 	if object["foo"] != "bar" {
 		t.Errorf("should return corect JSONObject")
 	}
-}
-
-func Test_FromJSON_WithIncorrectJSON_ShouldNotReturnCorrectJSONObject(t *testing.T) {
-	var (
-		object JSONObject
-		err    error
-	)
 
 	if object, err = FromJSON(``); err == nil {
 		t.Errorf("should NOT be able to parse JSON")
@@ -93,7 +83,7 @@ func Test_FromJSON_WithIncorrectJSON_ShouldNotReturnCorrectJSONObject(t *testing
 	}
 }
 
-func Test_WithNonce_ShouldAddNonce(t *testing.T) {
+func Test_JSONObject_WithNonce(t *testing.T) {
 	var (
 		object JSONObject = JSONObject{}
 	)

--- a/json_object_test.go
+++ b/json_object_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func Test_JSONObject_Equal(t *testing.T) {
+func TestJSONObject_Equal(t *testing.T) {
 	var shouldBeEquivalent bool = JSONObject{
 		"object": JSONObject{
 			"number": 1.23,
@@ -38,7 +38,7 @@ func Test_JSONObject_Equal(t *testing.T) {
 	}
 }
 
-func Test_JSONObject_String(t *testing.T) {
+func TestJSONObject_String(t *testing.T) {
 	var (
 		object = JSONObject{
 			"string": "i-am-string",
@@ -60,7 +60,7 @@ func Test_JSONObject_String(t *testing.T) {
 	}
 }
 
-func Test_FromJSON(t *testing.T) {
+func TestFromJSON(t *testing.T) {
 	var (
 		object JSONObject
 		err    error
@@ -83,7 +83,7 @@ func Test_FromJSON(t *testing.T) {
 	}
 }
 
-func Test_JSONObject_WithNonce(t *testing.T) {
+func TestJSONObject_WithNonce(t *testing.T) {
 	var (
 		object JSONObject = JSONObject{}
 	)

--- a/ledger/asset/asset_test.go
+++ b/ledger/asset/asset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/scalar-labs/dl/rpc"
 )
 
-func Test_ProofKey_Equal(t *testing.T) {
+func TestProofKey_Equal(t *testing.T) {
 	var shouldBeTrue = ProofKey{
 		ID:  "foo",
 		Age: 1,
@@ -35,7 +35,7 @@ func Test_ProofKey_Equal(t *testing.T) {
 	}
 }
 
-func Test_ProofKey_Compare(t *testing.T) {
+func TestProofKey_Compare(t *testing.T) {
 	var shouldBe0 = ProofKey{
 		ID:  "foo",
 		Age: 1,
@@ -97,7 +97,7 @@ func Test_ProofKey_Compare(t *testing.T) {
 	}
 }
 
-func Test_Proof_FromGRPC(t *testing.T) {
+func TestProof_FromGRPC(t *testing.T) {
 	var proof = FromGRPC(&rpc.AssetProof{
 		AssetId:   "foo",
 		Age:       999,
@@ -141,7 +141,7 @@ func Test_Proof_FromGRPC(t *testing.T) {
 	}
 }
 
-func Test_Proof_Equal(t *testing.T) {
+func TestProof_Equal(t *testing.T) {
 	var shouldBeTrue = Proof{
 		ID:        "foo",
 		Age:       999,
@@ -191,7 +191,7 @@ func Test_Proof_Equal(t *testing.T) {
 	}
 }
 
-func Test_Proof_ValueEqual(t *testing.T) {
+func TestProof_ValueEqual(t *testing.T) {
 	var shouldBeTrue = Proof{
 		ID:        "foo",
 		Age:       999,
@@ -237,7 +237,7 @@ func Test_Proof_ValueEqual(t *testing.T) {
 	}
 }
 
-func Test_Proof_Serialize(t *testing.T) {
+func TestProof_Serialize(t *testing.T) {
 	var (
 		proof = Proof{
 			ID:       "foo",
@@ -264,7 +264,7 @@ func Test_Proof_Serialize(t *testing.T) {
 	}
 }
 
-func Test_Proof_String(t *testing.T) {
+func TestProof_String(t *testing.T) {
 	var (
 		proof = Proof{
 			ID:        "foo",
@@ -284,7 +284,7 @@ func Test_Proof_String(t *testing.T) {
 	}
 }
 
-func Test_Proof_VerifyWith(t *testing.T) {
+func TestProof_VerifyWith(t *testing.T) {
 	var proof = Proof{
 		ID:       "foo",
 		Age:      999,

--- a/ledger/error/error_test.go
+++ b/ledger/error/error_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/scalar-labs/dl/ledger/statuscode"
 )
 
-func Test_NewLedgerError(t *testing.T) {
+func TestNewLedgerError(t *testing.T) {
 	var err LedgerError = NewLedgerError(400, "invalid signature")
 
 	if err.StatusCode() != statuscode.InvalidSignature {

--- a/ledger/error/error_test.go
+++ b/ledger/error/error_test.go
@@ -6,11 +6,8 @@ import (
 	"github.com/scalar-labs/dl/ledger/statuscode"
 )
 
-func Test_NewClientError_StatusCodeAndMessage_ShouldBeSuccessful(t *testing.T) {
-	var err LedgerError = LedgerError{
-		statusCode: 400,
-		message:    "invalid signature",
-	}
+func Test_NewLedgerError(t *testing.T) {
+	var err LedgerError = NewLedgerError(400, "invalid signature")
 
 	if err.StatusCode() != statuscode.InvalidSignature {
 		t.Errorf("should be created with correct status code")

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -14,7 +14,7 @@ XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==
 -----END EC PRIVATE KEY-----
 `
 
-func Test_ContractRegistrationRequest_Sign_ShouldSucceed(t *testing.T) {
+func Test_ContractRegistrationRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -41,7 +41,7 @@ func Test_ContractRegistrationRequest_Sign_ShouldSucceed(t *testing.T) {
 	}
 }
 
-func Test_ContractsListingRequest_Sign_ShouldSucceed(t *testing.T) {
+func Test_ContractsListingRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -65,7 +65,7 @@ func Test_ContractsListingRequest_Sign_ShouldSucceed(t *testing.T) {
 	}
 }
 
-func Test_ContractExecutionRequest_Sign_ShouldSucceed(t *testing.T) {
+func Test_ContractExecutionRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -90,7 +90,7 @@ func Test_ContractExecutionRequest_Sign_ShouldSucceed(t *testing.T) {
 	}
 }
 
-func Test_LedgerValidationRequest_Sign_ShouldSucceed(t *testing.T) {
+func Test_LedgerValidationRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -116,7 +116,7 @@ func Test_LedgerValidationRequest_Sign_ShouldSucceed(t *testing.T) {
 	}
 }
 
-func Test_LedgersValidationRequest_Sign_ShouldSucceed(t *testing.T) {
+func Test_LedgersValidationRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -139,7 +139,8 @@ func Test_LedgersValidationRequest_Sign_ShouldSucceed(t *testing.T) {
 		t.Errorf("signature should be filled")
 	}
 }
-func Test_AssetProofRetrievalRequest_Sign_ShouldSucceed(t *testing.T) {
+
+func Test_AssetProofRetrievalRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -164,7 +165,7 @@ func Test_AssetProofRetrievalRequest_Sign_ShouldSucceed(t *testing.T) {
 	}
 }
 
-func Test_ExecutionAbortRequest_SignWithSigner_ShouldSucceed(t *testing.T) {
+func Test_ExecutionAbortRequest_SignWithSigner(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -14,7 +14,7 @@ XYWdrgo0Y3eXEhvK0lsURO9N0nrPiQWT4A==
 -----END EC PRIVATE KEY-----
 `
 
-func Test_ContractRegistrationRequest_SignWith(t *testing.T) {
+func TestContractRegistrationRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -41,7 +41,7 @@ func Test_ContractRegistrationRequest_SignWith(t *testing.T) {
 	}
 }
 
-func Test_ContractsListingRequest_SignWith(t *testing.T) {
+func TestContractsListingRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -65,7 +65,7 @@ func Test_ContractsListingRequest_SignWith(t *testing.T) {
 	}
 }
 
-func Test_ContractExecutionRequest_SignWith(t *testing.T) {
+func TestContractExecutionRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -90,7 +90,7 @@ func Test_ContractExecutionRequest_SignWith(t *testing.T) {
 	}
 }
 
-func Test_LedgerValidationRequest_SignWith(t *testing.T) {
+func TestLedgerValidationRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -116,7 +116,7 @@ func Test_LedgerValidationRequest_SignWith(t *testing.T) {
 	}
 }
 
-func Test_LedgersValidationRequest_SignWith(t *testing.T) {
+func TestLedgersValidationRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -140,7 +140,7 @@ func Test_LedgersValidationRequest_SignWith(t *testing.T) {
 	}
 }
 
-func Test_AssetProofRetrievalRequest_SignWith(t *testing.T) {
+func TestAssetProofRetrievalRequest_SignWith(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error
@@ -165,7 +165,7 @@ func Test_AssetProofRetrievalRequest_SignWith(t *testing.T) {
 	}
 }
 
-func Test_ExecutionAbortRequest_SignWithSigner(t *testing.T) {
+func TestExecutionAbortRequest_SignWithSigner(t *testing.T) {
 	var (
 		signer  crypto.Signer
 		err     error


### PR DESCRIPTION
This PR revises unit-test case names to conform to with the following pattern

- Test_{function}
- Test_{type}_{function for the type}

For example, assuming a package `p` that defines a type `T`, a function `TF` for the type `T`, and a function `F` for the package `p` in this file,

```go
package p

type T int

func F() {
}

func (t T) TF {
}
```
then the test cases can be named as `Test_T_TF` and `Test_F`.

```
package p

import "testing"

func TestT_TF(tester *testing.T) {
}

func TestF(tester *testing.T) {
}
```

The error report (if happens) from running the test can directly and clearly address where the error happens.