### PR TITLE
Use Russ Cox package versioning

### DIFF
--- a/client/error/client_error.go
+++ b/client/error/client_error.go
@@ -1,6 +1,6 @@
 package error
 
-import "github.com/scalar-labs/dl/v3/ledger/statuscode"
+import "github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
 
 // ClientError is used when ClientService has errors.
 // It implements the Error interface.

--- a/client/error/client_error.go
+++ b/client/error/client_error.go
@@ -1,6 +1,6 @@
 package error
 
-import "github.com/scalar-labs/dl/ledger/statuscode"
+import "github.com/scalar-labs/dl/v3/ledger/statuscode"
 
 // ClientError is used when ClientService has errors.
 // It implements the Error interface.

--- a/client/error/error_test.go
+++ b/client/error/error_test.go
@@ -3,7 +3,7 @@ package error
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
 )
 
 func TestNewClientError(t *testing.T) {

--- a/client/error/error_test.go
+++ b/client/error/error_test.go
@@ -3,7 +3,7 @@ package error
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/ledger/statuscode"
+	"github.com/scalar-labs/dl/v3/ledger/statuscode"
 )
 
 func TestNewClientError(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scalar-labs/dl/v3
+module github.com/scalar-labs/scalardl-go-client-sdk/v3
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/scalar-labs/dl
+module github.com/scalar-labs/dl/v3
 
 go 1.17
 

--- a/ledger/asset/asset_test.go
+++ b/ledger/asset/asset_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/scalar-labs/dl/v3"
-	"github.com/scalar-labs/dl/v3/crypto"
-	"github.com/scalar-labs/dl/v3/rpc"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
 )
 
 func TestProofKey_Equal(t *testing.T) {

--- a/ledger/asset/asset_test.go
+++ b/ledger/asset/asset_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/scalar-labs/dl"
-	"github.com/scalar-labs/dl/crypto"
-	"github.com/scalar-labs/dl/rpc"
+	"github.com/scalar-labs/dl/v3"
+	"github.com/scalar-labs/dl/v3/crypto"
+	"github.com/scalar-labs/dl/v3/rpc"
 )
 
 func TestProofKey_Equal(t *testing.T) {

--- a/ledger/asset/proof.go
+++ b/ledger/asset/proof.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/scalar-labs/dl/v3"
-	"github.com/scalar-labs/dl/v3/crypto"
-	"github.com/scalar-labs/dl/v3/rpc"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
 )
 
 // Proof defines a proof stored in client-side to validate the server ledger states.

--- a/ledger/asset/proof.go
+++ b/ledger/asset/proof.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/scalar-labs/dl"
-	"github.com/scalar-labs/dl/crypto"
-	"github.com/scalar-labs/dl/rpc"
+	"github.com/scalar-labs/dl/v3"
+	"github.com/scalar-labs/dl/v3/crypto"
+	"github.com/scalar-labs/dl/v3/rpc"
 )
 
 // Proof defines a proof stored in client-side to validate the server ledger states.

--- a/ledger/error/error_test.go
+++ b/ledger/error/error_test.go
@@ -3,7 +3,7 @@ package error
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
 )
 
 func TestNewLedgerError(t *testing.T) {

--- a/ledger/error/error_test.go
+++ b/ledger/error/error_test.go
@@ -3,7 +3,7 @@ package error
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/ledger/statuscode"
+	"github.com/scalar-labs/dl/v3/ledger/statuscode"
 )
 
 func TestNewLedgerError(t *testing.T) {

--- a/ledger/error/ledger_error.go
+++ b/ledger/error/ledger_error.go
@@ -1,6 +1,6 @@
 package error
 
-import "github.com/scalar-labs/dl/v3/ledger/statuscode"
+import "github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
 
 // LedgerError represents the errors fromo Ledger.
 // It implements the Error interface.

--- a/ledger/error/ledger_error.go
+++ b/ledger/error/ledger_error.go
@@ -1,6 +1,6 @@
 package error
 
-import "github.com/scalar-labs/dl/ledger/statuscode"
+import "github.com/scalar-labs/dl/v3/ledger/statuscode"
 
 // LedgerError represents the errors fromo Ledger.
 // It implements the Error interface.

--- a/ledger/model/contract_execution_result.go
+++ b/ledger/model/contract_execution_result.go
@@ -3,8 +3,8 @@ package model
 import (
 	"fmt"
 
-	"github.com/scalar-labs/dl/v3"
-	"github.com/scalar-labs/dl/v3/ledger/asset"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/asset"
 )
 
 // ContractExecutionResult defines the result of a contract execution.

--- a/ledger/model/contract_execution_result.go
+++ b/ledger/model/contract_execution_result.go
@@ -3,8 +3,8 @@ package model
 import (
 	"fmt"
 
-	"github.com/scalar-labs/dl"
-	"github.com/scalar-labs/dl/ledger/asset"
+	"github.com/scalar-labs/dl/v3"
+	"github.com/scalar-labs/dl/v3/ledger/asset"
 )
 
 // ContractExecutionResult defines the result of a contract execution.

--- a/ledger/model/ledger_validation_result.go
+++ b/ledger/model/ledger_validation_result.go
@@ -1,8 +1,8 @@
 package model
 
 import (
-	"github.com/scalar-labs/dl/ledger/asset"
-	"github.com/scalar-labs/dl/ledger/statuscode"
+	"github.com/scalar-labs/dl/v3/ledger/asset"
+	"github.com/scalar-labs/dl/v3/ledger/statuscode"
 )
 
 // LedgerValidationResult defines the specified status code and the asset proof from Ledger and Auditor.

--- a/ledger/model/ledger_validation_result.go
+++ b/ledger/model/ledger_validation_result.go
@@ -1,8 +1,8 @@
 package model
 
 import (
-	"github.com/scalar-labs/dl/v3/ledger/asset"
-	"github.com/scalar-labs/dl/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/asset"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
 )
 
 // LedgerValidationResult defines the specified status code and the asset proof from Ledger and Auditor.

--- a/ledger/model/model_test.go
+++ b/ledger/model/model_test.go
@@ -3,9 +3,9 @@ package model
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl"
-	"github.com/scalar-labs/dl/ledger/asset"
-	"github.com/scalar-labs/dl/ledger/statuscode"
+	"github.com/scalar-labs/dl/v3"
+	"github.com/scalar-labs/dl/v3/ledger/asset"
+	"github.com/scalar-labs/dl/v3/ledger/statuscode"
 )
 
 func TestLedgerValidationResult_Equal(t *testing.T) {

--- a/ledger/model/model_test.go
+++ b/ledger/model/model_test.go
@@ -3,9 +3,9 @@ package model
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/v3"
-	"github.com/scalar-labs/dl/v3/ledger/asset"
-	"github.com/scalar-labs/dl/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/asset"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
 )
 
 func TestLedgerValidationResult_Equal(t *testing.T) {

--- a/rpc/request_signer.go
+++ b/rpc/request_signer.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"unsafe"
 
-	"github.com/scalar-labs/dl/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
 )
 
 // SignWith signs ContractRegistrationRequest with the given signer and fill the signature.

--- a/rpc/request_signer.go
+++ b/rpc/request_signer.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"unsafe"
 
-	"github.com/scalar-labs/dl/crypto"
+	"github.com/scalar-labs/dl/v3/crypto"
 )
 
 // SignWith signs ContractRegistrationRequest with the given signer and fill the signature.

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
 )
 
 const testKey = `

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"testing"
 
-	"github.com/scalar-labs/dl/crypto"
+	"github.com/scalar-labs/dl/v3/crypto"
 )
 
 const testKey = `


### PR DESCRIPTION
This PR uses https://go.dev/blog/versioning-proposal to rename the module from `github.com/scalar-labs/dl` to `github.com/scalar-labs/dl/v3`

Simply speaking, we should put the version into module name after version 1.