### PR TITLE
Implement client/service package

### DIFF
--- a/client/service/certificate_registration.go
+++ b/client/service/certificate_registration.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"context"
+
+	clientError "github.com/scalar-labs/scalardl-go-client-sdk/v3/client/error"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// RegisterCertificate registers the certificate in the client config to Ledger and Auditor.
+func (s ClientService) RegisterCertificate() (err error) {
+	if s.clientConfig.ClientMode != "CLIENT" {
+		return clientError.NewClientError(
+			statuscode.InvalidRequest,
+			"wrong mode specified",
+		)
+	}
+
+	var (
+		trailer metadata.MD
+		request = &rpc.CertificateRegistrationRequest{
+			CertHolderId: s.clientConfig.CertHolderID,
+			CertVersion:  (uint32)(s.clientConfig.CertVersion),
+			CertPem:      s.clientConfig.Cert,
+		}
+	)
+
+	if s.clientConfig.IsAuditorEnabled {
+		var privileged = rpc.NewAuditorPrivilegedClient(s.auditorPrivilegedConnection)
+
+		if _, err = privileged.RegisterCert(
+			context.Background(),
+			request,
+			grpc.Trailer(&trailer),
+		); err != nil {
+			if trailer.Len() > 0 {
+				err = getClientErrorFromTrailer(trailer)
+			}
+		}
+	}
+
+	var priviledged = rpc.NewLedgerPrivilegedClient(s.ledgerPrivilegedConnection)
+
+	trailer = metadata.MD{}
+
+	if _, err = priviledged.RegisterCert(
+		context.Background(),
+		request,
+		grpc.Trailer(&trailer),
+	); err != nil {
+		if trailer.Len() > 0 {
+			err = getClientErrorFromTrailer(trailer)
+		}
+	}
+
+	return
+}

--- a/client/service/client_service.go
+++ b/client/service/client_service.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/client/config"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// ClientService defines the interface of the client service.
+type ClientService struct {
+	clientConfig                config.ClientConfig
+	signer                      crypto.Signer
+	ledgerConnection            *grpc.ClientConn
+	ledgerPrivilegedConnection  *grpc.ClientConn
+	auditorConnection           *grpc.ClientConn
+	auditorPrivilegedConnection *grpc.ClientConn
+}
+
+// NewClientService creates ClientService instance.
+func NewClientService(c config.ClientConfig) (s ClientService, err error) {
+	if err = c.Validate(); err != nil {
+		return
+	}
+
+	s.clientConfig = c
+
+	if s.signer, err = crypto.NewEcdsaSha256Signer([]byte(c.PrivateKey)); err != nil {
+		return
+	}
+
+	var opts = make([]grpc.DialOption, 0)
+
+	if c.IsTLSEnabled {
+		var certPool *x509.CertPool = x509.NewCertPool()
+		if ok := certPool.AppendCertsFromPEM([]byte(c.TLSCaRootCert)); !ok {
+			err = fmt.Errorf("TLSCaRootCert is not valid")
+			return
+		}
+
+		var creds credentials.TransportCredentials = credentials.NewClientTLSFromCert(certPool, c.LedgerHost)
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithInsecure())
+	}
+
+	if s.ledgerConnection, err = grpc.Dial(
+		fmt.Sprintf("%s:%d", c.LedgerHost, c.LedgerPort),
+		opts...,
+	); err != nil {
+		return
+	}
+
+	if s.ledgerPrivilegedConnection, err = grpc.Dial(
+		fmt.Sprintf("%s:%d", c.LedgerHost, c.LedgerPrivilegedPort),
+		opts...,
+	); err != nil {
+		return
+	}
+
+	if c.IsAuditorEnabled {
+		opts = make([]grpc.DialOption, 0)
+
+		if c.IsAuditorTLSEnabled {
+			var certPool *x509.CertPool = x509.NewCertPool()
+			if ok := certPool.AppendCertsFromPEM([]byte(c.AuditorTLSCaRootCert)); !ok {
+				err = fmt.Errorf("AuditorTLSCaRootCert is not valid")
+				return
+			}
+
+			var creds credentials.TransportCredentials = credentials.NewClientTLSFromCert(certPool, c.AuditorHost)
+			opts = append(opts, grpc.WithTransportCredentials(creds))
+		} else {
+			opts = append(opts, grpc.WithInsecure())
+		}
+
+		if s.auditorConnection, err = grpc.Dial(
+			fmt.Sprintf("%s:%d", c.AuditorHost, c.AuditorPort),
+			opts...,
+		); err != nil {
+			return
+		}
+
+		if s.auditorPrivilegedConnection, err = grpc.Dial(
+			fmt.Sprintf("%s:%d", c.AuditorHost, c.AuditorPrivilegedPort),
+			opts...,
+		); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// Close shuts down underlying connections.
+func (s ClientService) Close() {
+	if s.ledgerConnection != nil {
+		s.ledgerConnection.Close()
+	}
+
+	if s.ledgerPrivilegedConnection != nil {
+		s.ledgerPrivilegedConnection.Close()
+	}
+
+	if s.auditorConnection != nil {
+		s.auditorConnection.Close()
+	}
+
+	if s.auditorPrivilegedConnection != nil {
+		s.auditorPrivilegedConnection.Close()
+	}
+}

--- a/client/service/contract_execution.go
+++ b/client/service/contract_execution.go
@@ -99,7 +99,7 @@ func (s ClientService) ExecuteContract(
 		return
 	}
 
-	// send the execution validation reqeust to Auditor.k
+	// send the execution validation reqeust to Auditor.
 	if s.clientConfig.IsAuditorEnabled {
 		trailer = metadata.MD{}
 

--- a/client/service/contract_execution.go
+++ b/client/service/contract_execution.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	clientError "github.com/scalar-labs/scalardl-go-client-sdk/v3/client/error"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/json"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/asset"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/model"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// ExecuteContract executes a registered contract.
+func (s ClientService) ExecuteContract(
+	id string,
+	argument json.Object,
+	functionArgument json.Object,
+) (result model.ContractExecutionResult, err error) {
+	if s.clientConfig.ClientMode != "CLIENT" {
+		return result, clientError.NewClientError(statuscode.InvalidRequest, "wrong mode specified")
+	}
+
+	if id == "" {
+		return result, fmt.Errorf("id cannot be empty")
+	}
+
+	if argument == nil {
+		return result, fmt.Errorf("argument cannot be nil")
+	}
+
+	if _, ok := argument["nonce"]; !ok {
+		argument["nonce"] = uuid.NewString()
+	}
+
+	if argument["nonce"] == "" {
+		argument["nonce"] = uuid.NewString()
+	}
+
+	var (
+		signer  crypto.Signer
+		request = &rpc.ContractExecutionRequest{
+			ContractId:       id,
+			CertHolderId:     s.clientConfig.CertHolderID,
+			CertVersion:      uint32(s.clientConfig.CertVersion),
+			ContractArgument: argument.String(),
+		}
+	)
+
+	if functionArgument != nil {
+		request.FunctionArgument = functionArgument.String()
+	}
+
+	if signer, err = crypto.NewEcdsaSha256Signer([]byte(s.clientConfig.PrivateKey)); err != nil {
+		return
+	}
+
+	if err = request.SignWith(signer); err != nil {
+		return
+	}
+
+	var (
+		auditor             rpc.AuditorClient
+		ledger              = rpc.NewLedgerClient(s.ledgerConnection)
+		trailer             metadata.MD
+		responseFromLedger  *rpc.ContractExecutionResponse
+		responseFromAuditor *rpc.ContractExecutionResponse
+	)
+
+	// send the ordering request to Auditor first to get Auditor's signature.
+	if s.clientConfig.IsAuditorEnabled {
+		auditor = rpc.NewAuditorClient(s.auditorConnection)
+		trailer = metadata.MD{}
+
+		var ordered *rpc.ExecutionOrderingResponse
+		if ordered, err = auditor.OrderExecution(context.Background(), request, grpc.Trailer(&trailer)); err != nil {
+			if trailer.Len() > 0 {
+				err = getClientErrorFromTrailer(trailer)
+			}
+
+			return
+		}
+
+		request.AuditorSignature = ordered.GetSignature()
+	}
+
+	trailer = metadata.MD{}
+	if responseFromLedger, err = ledger.ExecuteContract(context.Background(), request, grpc.Trailer(&trailer)); err != nil {
+		if trailer.Len() > 0 {
+			err = getClientErrorFromTrailer(trailer)
+		}
+
+		return
+	}
+
+	// send the execution validation reqeust to Auditor.k
+	if s.clientConfig.IsAuditorEnabled {
+		trailer = metadata.MD{}
+
+		if responseFromAuditor, err = auditor.ValidateExecution(
+			context.Background(),
+			&rpc.ExecutionValidationRequest{
+				Request: request,
+				Proofs:  responseFromLedger.GetProofs(),
+			},
+			grpc.Trailer(&trailer),
+		); err != nil {
+			if trailer.Len() > 0 {
+				err = getClientErrorFromTrailer(trailer)
+			}
+
+			return
+		}
+
+		if responseFromLedger.GetResult() != responseFromAuditor.GetResult() ||
+			len(responseFromLedger.GetProofs()) != len(responseFromAuditor.GetProofs()) {
+			return result, clientError.NewClientError(
+				statuscode.InconsistentStates,
+				"The results from Ledger and Auditor don't match",
+			)
+		}
+
+		var proofsFromLedger map[string]*rpc.AssetProof = make(map[string]*rpc.AssetProof)
+
+		for _, p1 := range responseFromLedger.GetProofs() {
+			proofsFromLedger[p1.GetAssetId()] = p1
+		}
+
+		for _, p2 := range responseFromAuditor.GetProofs() {
+			p1, ok := proofsFromLedger[p2.GetAssetId()]
+
+			if !ok || p1.GetAge() != p2.GetAge() || !bytes.Equal(p1.GetHash(), p2.GetHash()) {
+				return result, clientError.NewClientError(
+					statuscode.InconsistentStates,
+					"The results from Ledger and Auditor don't match",
+				)
+			}
+		}
+
+		for _, p := range responseFromAuditor.GetProofs() {
+			result.AuditorProofs = append(result.AuditorProofs, asset.FromGRPC(p))
+		}
+	}
+
+	result.Result, _ = json.FromJSON(responseFromLedger.Result)
+
+	for _, p := range responseFromLedger.GetProofs() {
+		result.Proofs = append(result.Proofs, asset.FromGRPC(p))
+	}
+
+	return
+}

--- a/client/service/contract_registration.go
+++ b/client/service/contract_registration.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	clientError "github.com/scalar-labs/scalardl-go-client-sdk/v3/client/error"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/json"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// RegisterContract registers contract to Scalar DL networks.
+func (s ClientService) RegisterContract(
+	id string,
+	name string,
+	contractBytes []byte,
+	properties json.Object,
+) (err error) {
+	if s.clientConfig.ClientMode != "CLIENT" {
+		return clientError.NewClientError(statuscode.InvalidRequest, "wrong mode specified")
+	}
+
+	if id == "" {
+		return fmt.Errorf("id cannot be empty")
+	}
+
+	if name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+
+	if contractBytes == nil {
+		return fmt.Errorf("contractBytes cannot be nil")
+	}
+
+	var (
+		signer  crypto.Signer
+		trailer metadata.MD
+		request = &rpc.ContractRegistrationRequest{
+			ContractId:         id,
+			ContractBinaryName: name,
+			ContractByteCode:   contractBytes,
+			CertHolderId:       s.clientConfig.CertHolderID,
+			CertVersion:        uint32(s.clientConfig.CertVersion),
+		}
+	)
+
+	if properties != nil {
+		request.ContractProperties = properties.String()
+	}
+
+	if signer, err = crypto.NewEcdsaSha256Signer([]byte(s.clientConfig.PrivateKey)); err != nil {
+		return
+	}
+
+	if err = request.SignWith(signer); err != nil {
+		return
+	}
+
+	if s.clientConfig.IsAuditorEnabled {
+		var auditor = rpc.NewAuditorClient(s.auditorConnection)
+		if _, err := auditor.RegisterContract(context.Background(), request, grpc.Trailer(&trailer)); err != nil {
+			if trailer.Len() > 0 {
+				err = getClientErrorFromTrailer(trailer)
+			}
+
+			return err
+		}
+	}
+
+	trailer = metadata.MD{}
+	var ledger = rpc.NewLedgerClient(s.ledgerConnection)
+	if _, err := ledger.RegisterContract(context.Background(), request, grpc.Trailer(&trailer)); err != nil {
+		if trailer.Len() > 0 {
+			err = getClientErrorFromTrailer(trailer)
+		}
+
+		return err
+	}
+
+	return
+}

--- a/client/service/ledger_validation.go
+++ b/client/service/ledger_validation.go
@@ -55,7 +55,7 @@ func (s ClientService) ValidateLedger(args ...interface{}) (result model.LedgerV
 		return result, fmt.Errorf("assetID cannot be empty")
 	}
 
-	if endAge < startAge || startAge < 0 {
+	if endAge < startAge || startAge < 0 || endAge > JavaMaxIntValue {
 		return result, fmt.Errorf("invalid ages specified")
 	}
 
@@ -68,9 +68,8 @@ func (s ClientService) ValidateLedger(args ...interface{}) (result model.LedgerV
 			"asset_id": assetID,
 		}
 
-		if endAge != JavaMaxIntValue {
-			argument["age"] = endAge
-		}
+		argument["start_age"] = startAge
+		argument["end_age"] = endAge
 
 		var executed model.ContractExecutionResult
 

--- a/client/service/ledger_validation.go
+++ b/client/service/ledger_validation.go
@@ -1,0 +1,192 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	clientError "github.com/scalar-labs/scalardl-go-client-sdk/v3/client/error"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/crypto"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/json"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/asset"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/model"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// JavaMaxIntValue defines a value according to Java's max value of int.
+const JavaMaxIntValue = 2147483647
+
+// ValidateLedger validates the specified asset between the specified ages.
+func (s ClientService) ValidateLedger(args ...interface{}) (result model.LedgerValidationResult, err error) {
+	if s.clientConfig.ClientMode != "CLIENT" {
+		return result, clientError.NewClientError(statuscode.InvalidRequest, "wrong mode specified")
+	}
+
+	var (
+		assetID  string
+		startAge int = 0
+		endAge   int = JavaMaxIntValue
+		signer   crypto.Signer
+		ok       bool
+	)
+
+	if len(args) > 0 {
+		if assetID, ok = args[0].(string); !ok {
+			return result, fmt.Errorf("assetID must be a string")
+		}
+	}
+
+	if len(args) > 1 {
+		if startAge, ok = args[1].(int); !ok {
+			return result, fmt.Errorf("startAge must be an integer")
+		}
+	}
+
+	if len(args) > 2 {
+		if endAge, ok = args[2].(int); !ok {
+			return result, fmt.Errorf("endAge must be an integer")
+		}
+	}
+
+	if assetID == "" {
+		return result, fmt.Errorf("assetID cannot be empty")
+	}
+
+	if endAge < startAge || startAge < 0 {
+		return result, fmt.Errorf("invalid ages specified")
+	}
+
+	if signer, err = crypto.NewEcdsaSha256Signer([]byte(s.clientConfig.PrivateKey)); err != nil {
+		return
+	}
+
+	if s.clientConfig.IsAuditorEnabled && s.clientConfig.IsAuditorLinearizableValidationEnabled {
+		argument := json.Object{
+			"asset_id": assetID,
+		}
+
+		if endAge != JavaMaxIntValue {
+			argument["age"] = endAge
+		}
+
+		var executed model.ContractExecutionResult
+
+		if executed, err = s.ExecuteContract(
+			s.clientConfig.AuditorLinearizableValidationContractID,
+			argument,
+			nil,
+		); err != nil {
+			return
+		}
+
+		result.Code = statuscode.OK
+
+		if len(executed.Proofs) > 0 {
+			result.Proof = executed.Proofs[0]
+		}
+
+		if len(executed.AuditorProofs) > 0 {
+			result.AuditorProof = executed.AuditorProofs[0]
+		}
+	} else {
+		var request *rpc.LedgerValidationRequest = &rpc.LedgerValidationRequest{
+			AssetId:      assetID,
+			StartAge:     uint32(startAge),
+			EndAge:       uint32(endAge),
+			CertHolderId: s.clientConfig.CertHolderID,
+			CertVersion:  uint32(s.clientConfig.CertVersion),
+		}
+
+		if err = request.SignWith(signer); err != nil {
+			return
+		}
+
+		var (
+			ledgerChan          chan *rpc.LedgerValidationResponse = make(chan *rpc.LedgerValidationResponse)
+			auditorChan         chan *rpc.LedgerValidationResponse = make(chan *rpc.LedgerValidationResponse)
+			ledgerErrorChan     chan error                         = make(chan error)
+			auditorErrorChan    chan error                         = make(chan error)
+			responseFromLedger  *rpc.LedgerValidationResponse
+			responseFromAuditor *rpc.LedgerValidationResponse
+		)
+
+		defer close(ledgerChan)
+		defer close(auditorChan)
+		defer close(ledgerErrorChan)
+		defer close(auditorErrorChan)
+
+		go func(r chan *rpc.LedgerValidationResponse, e chan error) {
+			if !s.clientConfig.IsAuditorEnabled {
+				r <- nil
+				e <- nil
+			}
+
+			auditor := rpc.NewAuditorClient(s.auditorConnection)
+			trailer := metadata.MD{}
+
+			response, err := auditor.ValidateLedger(context.Background(), request, grpc.Trailer(&trailer))
+
+			if err != nil && trailer.Len() > 0 {
+				err = getClientErrorFromTrailer(trailer)
+			}
+
+			r <- response
+			e <- err
+
+			close(r)
+			close(e)
+		}(auditorChan, auditorErrorChan)
+
+		go func(r chan *rpc.LedgerValidationResponse, e chan error) {
+			ledger := rpc.NewLedgerClient(s.ledgerConnection)
+			trailer := metadata.MD{}
+
+			response, err := ledger.ValidateLedger(context.Background(), request, grpc.Trailer(&trailer))
+
+			if err != nil && trailer.Len() > 0 {
+				err = getClientErrorFromTrailer(trailer)
+			}
+
+			r <- response
+			e <- err
+			close(r)
+			close(e)
+		}(ledgerChan, ledgerErrorChan)
+
+		if responseFromLedger, err = <-ledgerChan, <-ledgerErrorChan; err != nil {
+			return
+		}
+
+		if responseFromAuditor, err = <-auditorChan, <-auditorErrorChan; err != nil {
+			return
+		}
+
+		if !s.clientConfig.IsAuditorEnabled {
+			result.Code = statuscode.StatusCode(responseFromLedger.StatusCode)
+			result.Proof = asset.FromGRPC(responseFromLedger.Proof)
+		} else {
+			var (
+				p1   asset.Proof           = asset.FromGRPC(responseFromLedger.Proof)
+				p2   asset.Proof           = asset.FromGRPC(responseFromAuditor.Proof)
+				code statuscode.StatusCode = statuscode.InconsistentStates
+			)
+
+			if responseFromLedger.StatusCode == statuscode.OK &&
+				responseFromAuditor.StatusCode == statuscode.OK &&
+				!p1.Equal(asset.Proof{}) &&
+				!p2.Equal(asset.Proof{}) &&
+				bytes.Equal(p1.Hash, p2.Hash) {
+				code = statuscode.OK
+			}
+
+			result.Code = code
+			result.Proof = p1
+			result.AuditorProof = p2
+		}
+	}
+
+	return
+}

--- a/client/service/util.go
+++ b/client/service/util.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	clientError "github.com/scalar-labs/scalardl-go-client-sdk/v3/client/error"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/ledger/statuscode"
+	"github.com/scalar-labs/scalardl-go-client-sdk/v3/rpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+)
+
+func getClientErrorFromTrailer(trailer metadata.MD) (err clientError.ClientError) {
+	err = clientError.NewClientError(statuscode.UnknownTransactionStatus, "")
+
+	var statusInTailer []string = trailer.Get("rpc.status-bin")
+	if len(statusInTailer) == 0 {
+		return
+	}
+
+	var (
+		status        rpc.Status
+		statusInBytes = []byte(statusInTailer[0])
+	)
+	if e := proto.Unmarshal(statusInBytes, &status); e == nil {
+		err = clientError.NewClientError(
+			statuscode.StatusCode(status.GetCode()),
+			status.GetMessage(),
+		)
+	}
+
+	return
+}


### PR DESCRIPTION
This PR implements the `client/service` package that contains the following main interfaces:
- ClientService.RegisterCertificate
- ClientService.RegisterContract
- ClientService.ExecuteContract
- ClientService.ValidateLedger

The end-to-end test and example will be proposed in another PR.