### PR TITLE
Create retract for v3.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,8 @@ require (
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+retract (
+	v3.5.1 // Contains retractions only.
+	v3.5.0 // Published accidentally.
+)


### PR DESCRIPTION
This PR creates a GO module `retract` for a by accident release v3.5.0.
The reference for `retract` can be found [here](https://go.dev/ref/mod#go-mod-file-retract)