### PR TITLE
Create retract for v3.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,6 @@ require (
 retract (
 	v3.5.1 // Contains retractions only.
 	v3.5.0 // Published accidentally.
+	v3.0.1 // Contains retractions only.
+	v3.0.0 // Published accidentally.
 )


### PR DESCRIPTION
This PR creates a GO module `retract` for a by accident release v3.0.0.
The reference for `retract` can be found [here](https://go.dev/ref/mod#go-mod-file-retract)